### PR TITLE
Add a tracing option

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,17 @@
           "default": 3,
           "description": "The number of default accounts to create",
           "scope": "resource"
+        },
+        "cadence.trace.server": {
+          "scope": "window",
+          "type": "string",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off",
+          "description": "Traces the communication between VS Code and the Cadence language server."
         }
       }
     },


### PR DESCRIPTION
Add an option that traces the communication between the language server and the language client.
It is turned off by default. This helps with the development / debugging of the extension and the Cadence language server.

This is just adding a UI option in the settings. The actual functionality is provided by `vscode-languageclient`. See https://code.visualstudio.com/api/language-extensions/language-server-extension-guide#logging-support-for-language-server

<img width="969" alt="Screen Shot 2020-07-21 at 12 46 09 PM" src="https://user-images.githubusercontent.com/51661/88099554-2e21a300-cb50-11ea-9096-a80b42b330bb.png">

