### PR TITLE
Remove service account, hide account switcher until emulator is running

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -81,8 +81,12 @@ const startEmulator = (ext: Extension) => async () => {
     try {
       const accounts = await ext.api.createDefaultAccounts(ext.config.numAccounts);
       accounts.forEach((address) => ext.config.addAccount(address));
+      
       renderExtension(ext);
     } catch (err) {
+      ext.setEmulatorState(EmulatorState.Stopped);
+      renderExtension(ext);
+
       console.error("Failed to create default accounts", err);
       window.showWarningMessage("Failed to create default accounts");
     }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -6,7 +6,7 @@ import {
   window,
   workspace,
 } from "vscode";
-import { Extension, renderExtension } from "./extension";
+import { Extension, renderExtension, EmulatorState } from "./extension";
 import { LanguageServerAPI } from "./language-server";
 import { createTerminal } from "./terminal";
 import { removeAddressPrefix } from "./address";
@@ -54,6 +54,9 @@ const startEmulator = (ext: Extension) => async () => {
   // Start the emulator with the service key we gave to the language server.
   const { serverConfig } = ext.config;
 
+  ext.setEmulatorState(EmulatorState.Starting);
+  renderExtension(ext);
+
   ext.terminal.sendText(
     [
       ext.config.flowCommand,
@@ -70,7 +73,8 @@ const startEmulator = (ext: Extension) => async () => {
     ].join(" ")
   );
   ext.terminal.show();
-  ext.isEmulatorRunning = true;
+
+  ext.setEmulatorState(EmulatorState.Started);
 
   // create default accounts after the emulator has started
   setTimeout(async () => {
@@ -90,7 +94,8 @@ const stopEmulator = (ext: Extension) => async () => {
   ext.terminal.dispose();
   ext.terminal = createTerminal(ext.ctx);
 
-  ext.isEmulatorRunning = false;
+  ext.setEmulatorState(EmulatorState.Stopped);
+
   // Clear accounts and restart language server to ensure account
   // state is in sync.
   ext.config.resetAccounts();

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,7 +37,7 @@ type ServerConfig = {
 
 // The configuration used by the extension.
 export class Config {
-  // The name of the flow CLI executable
+  // The name of the Flow CLI executable.
   flowCommand: string;
   serverConfig: ServerConfig;
   numAccounts: number;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,8 +1,6 @@
 import { commands, window, workspace } from "vscode";
 import { addAddressPrefix } from "./address";
 
-export const SERVICE_ADDR: string = "f8d6e0586b0a20c7";
-
 const CONFIG_FLOW_COMMAND = "flowCommand";
 const CONFIG_SERVICE_PRIVATE_KEY = "servicePrivateKey";
 const CONFIG_SERVICE_KEY_SIGNATURE_ALGORITHM = "serviceKeySignatureAlgorithm";
@@ -21,7 +19,7 @@ export class Account {
   }
 
   name(): string {
-    return this.index === 0 ? "Service Account" : `Account ${this.index}`;
+    return `Account ${this.index + 1}`;
   }
 
   fullName(): string {
@@ -47,7 +45,7 @@ export class Config {
   // Mapping from account address to account object.
   accounts: Array<Account>;
   // Index of the currently active account.
-  activeAccount: number;
+  activeAccount: number | null;
 
   constructor(
     flowCommand: string,
@@ -57,20 +55,28 @@ export class Config {
     this.flowCommand = flowCommand;
     this.numAccounts = numAccounts;
     this.serverConfig = serverConfig;
-    this.accounts = [new Account(0, SERVICE_ADDR)];
-    this.activeAccount = 0;
+    this.accounts = [];
+    this.activeAccount = null;
   }
 
   addAccount(address: string) {
     const index = this.accounts.length;
     this.accounts.push(new Account(index, address));
+
+    if (index == 0) {
+      this.setActiveAccount(0);
+    }
   }
 
   setActiveAccount(index: number) {
     this.activeAccount = index;
   }
 
-  getActiveAccount(): Account {
+  getActiveAccount(): Account | null {
+    if (this.activeAccount == null) {
+      return null;
+    }
+
     return this.accounts[this.activeAccount];
   }
 
@@ -84,8 +90,8 @@ export class Config {
 
   // Resets account state
   resetAccounts() {
-    this.accounts = [new Account(0, SERVICE_ADDR)];
-    this.activeAccount = 0;
+    this.accounts = [];
+    this.activeAccount = null;
   }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,12 @@ import {getConfig, handleConfigChanges, Config} from "./config";
 import {LanguageServerAPI} from "./language-server";
 import {registerCommands} from "./commands";
 import {createTerminal} from "./terminal";
-import {createActiveAccountStatusBarItem, updateActiveAccountStatusBarItem} from "./status-bar";
+import {
+    createEmulatorStatusBarItem, 
+    updateEmulatorStatusBarItem,
+    createActiveAccountStatusBarItem, 
+    updateActiveAccountStatusBarItem, 
+} from "./status-bar";
 
 // The container for all data relevant to the extension.
 export type Extension = {
@@ -16,6 +21,8 @@ export type Extension = {
     ctx: ExtensionContext
     api: LanguageServerAPI
     terminal: Terminal
+    isEmulatorRunning: boolean;
+    emulatorStatusBarItem: StatusBarItem
     activeAccountStatusBarItem: StatusBarItem
 };
 
@@ -24,14 +31,12 @@ export type Extension = {
 export function activate(ctx: ExtensionContext) {
     let config: Config;
     let terminal: Terminal;
-    let activeAccountStatusBarItem: StatusBarItem;
     let api: LanguageServerAPI;
 
     try {
         config = getConfig();
         terminal = createTerminal(ctx);
         api = new LanguageServerAPI(ctx, config);
-        activeAccountStatusBarItem = createActiveAccountStatusBarItem();
     } catch (err) {
         window.showErrorMessage("Failed to activate extension: ", err);
         return;
@@ -43,7 +48,9 @@ export function activate(ctx: ExtensionContext) {
         ctx: ctx,
         api: api,
         terminal: terminal,
-        activeAccountStatusBarItem: activeAccountStatusBarItem,
+        isEmulatorRunning: false,
+        emulatorStatusBarItem: createEmulatorStatusBarItem(),
+        activeAccountStatusBarItem: createActiveAccountStatusBarItem(),
     };
 
     registerCommands(ext);
@@ -53,5 +60,6 @@ export function activate(ctx: ExtensionContext) {
 export function deactivate() {}
 
 export function renderExtension(ext: Extension) {
+    updateEmulatorStatusBarItem(ext.emulatorStatusBarItem, ext.isEmulatorRunning);
     updateActiveAccountStatusBarItem(ext.activeAccountStatusBarItem, ext.config.getActiveAccount());
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,15 +16,45 @@ import {
 } from "./status-bar";
 
 // The container for all data relevant to the extension.
-export type Extension = {
-    config: Config
-    ctx: ExtensionContext
-    api: LanguageServerAPI
-    terminal: Terminal
-    isEmulatorRunning: boolean;
-    emulatorStatusBarItem: StatusBarItem
-    activeAccountStatusBarItem: StatusBarItem
+export class Extension {
+    config: Config;
+    ctx: ExtensionContext;
+    api: LanguageServerAPI;
+    terminal: Terminal;
+    emulatorState: EmulatorState = EmulatorState.Stopped;
+    emulatorStatusBarItem: StatusBarItem;
+    activeAccountStatusBarItem: StatusBarItem;
+
+    constructor(
+        config: Config,
+        ctx: ExtensionContext,
+        api: LanguageServerAPI,
+        terminal: Terminal,
+        emulatorStatusBarItem: StatusBarItem,
+        activeAccountStatusBarItem: StatusBarItem,
+    ) {
+        this.config = config;
+        this.ctx = ctx;
+        this.api = api;
+        this.terminal = terminal;
+        this.emulatorStatusBarItem = emulatorStatusBarItem;
+        this.activeAccountStatusBarItem = activeAccountStatusBarItem;
+    }
+
+    getEmulatorState(): EmulatorState {
+        return this.emulatorState;
+    }
+
+    setEmulatorState(state: EmulatorState) {
+        this.emulatorState = state;
+    }
 };
+
+export enum EmulatorState {
+    Stopped = 1,
+    Starting,
+    Started,
+}
 
 // Called when the extension starts up. Reads config, starts the language
 // server, and registers command handlers.
@@ -43,15 +73,14 @@ export function activate(ctx: ExtensionContext) {
     }
     handleConfigChanges();
 
-    const ext: Extension = {
-        config: config,
-        ctx: ctx,
-        api: api,
-        terminal: terminal,
-        isEmulatorRunning: false,
-        emulatorStatusBarItem: createEmulatorStatusBarItem(),
-        activeAccountStatusBarItem: createActiveAccountStatusBarItem(),
-    };
+    const ext = new Extension(
+        config,
+        ctx,
+        api,
+        terminal,
+        createEmulatorStatusBarItem(),
+        createActiveAccountStatusBarItem(),
+    )
 
     registerCommands(ext);
     renderExtension(ext);
@@ -60,6 +89,6 @@ export function activate(ctx: ExtensionContext) {
 export function deactivate() {}
 
 export function renderExtension(ext: Extension) {
-    updateEmulatorStatusBarItem(ext.emulatorStatusBarItem, ext.isEmulatorRunning);
+    updateEmulatorStatusBarItem(ext.emulatorStatusBarItem, ext.getEmulatorState());
     updateActiveAccountStatusBarItem(ext.activeAccountStatusBarItem, ext.config.getActiveAccount());
 }

--- a/src/status-bar.ts
+++ b/src/status-bar.ts
@@ -5,18 +5,26 @@ import {
 } from "vscode";
 import {Account} from "./config";
 import {SWITCH_ACCOUNT, START_EMULATOR, STOP_EMULATOR} from "./commands";
+import { EmulatorState } from "./extension";
 
 export function createEmulatorStatusBarItem(): StatusBarItem {
     return window.createStatusBarItem(StatusBarAlignment.Left, 200);
 }
 
-export function updateEmulatorStatusBarItem(statusBarItem: StatusBarItem, isRunning: boolean): void {
-    if (isRunning) {
-        statusBarItem.command = STOP_EMULATOR;
-        statusBarItem.text = "$(debug-stop) Stop Flow Emulator"
-    } else {
-        statusBarItem.command = START_EMULATOR;
-        statusBarItem.text = "$(debug-start) Start Flow Emulator"
+export function updateEmulatorStatusBarItem(statusBarItem: StatusBarItem, emulatorState: EmulatorState): void {
+    switch (emulatorState) {
+        case EmulatorState.Stopped:
+            statusBarItem.command = START_EMULATOR;
+            statusBarItem.text = "$(debug-start) Start Flow Emulator"
+            break;
+        case EmulatorState.Starting:
+            statusBarItem.command = undefined;
+            statusBarItem.text = "$(loading~spin) Emulator starting..."
+            break;
+        case EmulatorState.Started:
+            statusBarItem.command = STOP_EMULATOR;
+            statusBarItem.text = "$(debug-stop) Stop Flow Emulator"
+            break;
     }
 
     statusBarItem.show()

--- a/src/status-bar.ts
+++ b/src/status-bar.ts
@@ -4,7 +4,24 @@ import {
     StatusBarAlignment,
 } from "vscode";
 import {Account} from "./config";
-import {SWITCH_ACCOUNT} from "./commands";
+import {SWITCH_ACCOUNT, START_EMULATOR, STOP_EMULATOR} from "./commands";
+
+export function createEmulatorStatusBarItem(): StatusBarItem {
+    return window.createStatusBarItem(StatusBarAlignment.Left, 200);
+}
+
+export function updateEmulatorStatusBarItem(statusBarItem: StatusBarItem, isRunning: boolean): void {
+    if (isRunning) {
+        statusBarItem.command = STOP_EMULATOR;
+        statusBarItem.text = "$(debug-stop) Stop Flow Emulator"
+    } else {
+        statusBarItem.command = START_EMULATOR;
+        statusBarItem.text = "$(debug-start) Start Flow Emulator"
+    }
+
+    statusBarItem.show()
+}
+
 
 export function createActiveAccountStatusBarItem(): StatusBarItem {
     const statusBarItem = window.createStatusBarItem(StatusBarAlignment.Left, 100);
@@ -12,7 +29,12 @@ export function createActiveAccountStatusBarItem(): StatusBarItem {
     return statusBarItem
 }
 
-export function updateActiveAccountStatusBarItem(statusBarItem: StatusBarItem, activeAccount: Account): void {
+export function updateActiveAccountStatusBarItem(statusBarItem: StatusBarItem, activeAccount: Account | null): void {
+    if (activeAccount == null) {
+        statusBarItem.hide()
+        return;
+    }
+
     statusBarItem.text = `$(key) Active account: ${activeAccount.fullName()}`
     statusBarItem.show()
 }


### PR DESCRIPTION
- Remove service account entirely from extension state
- Set `activeAccount = null` if no accounts created yet
- Once emulator is started and first account exists, set it as active 
- Once at least one account exists, display account switcher
- Add Start/Stop button for emulator