### PR TITLE
Add all commands to list of activation events

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,11 @@
   ],
   "activationEvents": [
     "onLanguage:cadence",
-    "onCommand:cadence.runEmulator"
+    "onCommand:cadence.restartServer",
+    "onCommand:cadence.runEmulator",
+    "onCommand:cadence.stopEmulator",
+    "onCommand:cadence.createAccount",
+    "onCommand:cadence.switchActiveAccount"
   ],
   "main": "./out/extension.js",
   "contributes": {


### PR DESCRIPTION
Ensure the extension is started whenever any of the commands is invoked.

Unfortunately it doesn't seem possible to use a wildcard yet: https://github.com/microsoft/vscode/issues/16045