### PR TITLE
Fix and improve syntax highlighting

### DIFF
--- a/syntaxes/cadence.tmGrammar.json
+++ b/syntaxes/cadence.tmGrammar.json
@@ -282,6 +282,10 @@
           {
             "match": "&&|\\|\\|",
             "name": "keyword.operator.logical.cadence"
+          },
+          {
+            "match": "[?!]",
+            "name": "keyword.operator.type.optional.cadence"
           }
         ]
       },

--- a/syntaxes/cadence.tmGrammar.json
+++ b/syntaxes/cadence.tmGrammar.json
@@ -304,7 +304,7 @@
             "name": "keyword.control.loop.cadence"
           },
           {
-            "match": "(?<!\\.)\\b(?:pre|post|prepare|execute|import|from|create|destroy|emit)\\b",
+            "match": "(?<!\\.)\\b(?:pre|post|prepare|execute|create|destroy|emit)\\b",
             "name": "keyword.other.cadence"
           },
           {
@@ -314,6 +314,10 @@
           {
             "match": "\\binit\\b|\\bdestroy\\b|(?<!\\.)\\b(?:get|set)\\b",
             "name": "storage.type.function.cadence"
+          },
+          {
+            "match": "(?<!\\.)\\b(?:import|from)\\b",
+            "name": "keyword.control.import.cadence"
           }
         ]
       },

--- a/syntaxes/cadence.tmGrammar.json
+++ b/syntaxes/cadence.tmGrammar.json
@@ -312,7 +312,7 @@
             "name": "keyword.other.declaration-specifier.accessibility.cadence"
           },
           {
-            "match": "\\binit\\b|\\bdestroy\\b|(?<!\\.)\\b(?:get|set)\\b",
+            "match": "\\b(?:init|destroy)\\b",
             "name": "storage.type.function.cadence"
           },
           {

--- a/syntaxes/cadence.tmGrammar.json
+++ b/syntaxes/cadence.tmGrammar.json
@@ -6,7 +6,8 @@
       { "include": "#declarations" },
       { "include": "#keywords" },
       { "include": "#code-block" },
-      { "include": "#composite" }
+      { "include": "#composite" },
+      { "include": "#event" }
     ],
     "repository": {
       "comments": {
@@ -308,7 +309,7 @@
             "name": "keyword.other.cadence"
           },
           {
-            "match": "(?<!\\.)\\b(?:private|pub(?:\\(set\\))?)\\b",
+            "match": "(?<!\\.)\\b(?:private|pub(?:\\(set\\))?|access\\((?:self|contract|account|all)\\))\\b",
             "name": "keyword.other.declaration-specifier.accessibility.cadence"
           },
           {
@@ -611,8 +612,29 @@
           }
         ]
       },
+      "event": {
+        "begin": "\\b(event)\\b\\s+([\\p{L}_][\\p{L}_\\p{N}\\p{M}]*)\\s*",
+        "beginCaptures": {
+          "1": {
+            "name": "storage.type.event.cadence"
+          },
+          "2": {
+            "name": "entity.name.type.event.cadence"
+          }
+        },
+        "end": "(?<=\\))|$",
+        "name": "meta.definition.type.event.cadence",
+        "patterns": [
+          {
+            "include": "#comments"
+          },
+          {
+            "include": "#parameter-clause"
+          }
+        ]
+      },
       "composite": {
-        "begin": "\\b((?:(?:struct|resource|contract)(?:\\s+interface)?)|transaction|event)\\s+([\\p{L}_][\\p{L}_\\p{N}\\p{M}]*)",
+        "begin": "\\b((?:(?:struct|resource|contract)(?:\\s+interface)?)|transaction|enum)\\s+([\\p{L}_][\\p{L}_\\p{N}\\p{M}]*)",
         "beginCaptures": {
           "1": {
             "name": "storage.type.$1.cadence"

--- a/syntaxes/cadence.tmGrammar.json
+++ b/syntaxes/cadence.tmGrammar.json
@@ -628,6 +628,9 @@
             "include": "#comments"
           },
           {
+            "include": "#conformance-clause"
+          },
+          {
             "begin": "\\{",
             "beginCaptures": {
               "0": {
@@ -644,6 +647,33 @@
             "patterns": [
               {
                 "include": "$self"
+              }
+            ]
+          }
+        ]
+      },
+      "conformance-clause": {
+        "begin": "(:)(?=\\s*\\{)|(:)\\s*",
+        "beginCaptures": {
+          "1": {
+            "name": "invalid.illegal.empty-conformance-clause.cadence"
+          },
+          "2": {
+            "name": "punctuation.separator.conformance-clause.cadence"
+          }
+        },
+        "end": "(?!\\G)$|(?=[={}])",
+        "name": "meta.conformance-clause.cadence",
+        "patterns": [
+          {
+            "begin": "\\G",
+            "end": "(?!\\G)$|(?=[={}])",
+            "patterns": [
+              {
+                "include": "#comments"
+              },
+              {
+                "include": "#type"
               }
             ]
           }

--- a/syntaxes/cadence.tmGrammar.json
+++ b/syntaxes/cadence.tmGrammar.json
@@ -268,10 +268,6 @@
             "name": "keyword.operator.arithmetic.cadence"
           },
           {
-            "match": "&(\\+|\\-|\\*)",
-            "name": "keyword.operator.arithmetic.overflow.cadence"
-          },
-          {
             "match": "%",
             "name": "keyword.operator.arithmetic.remainder.cadence"
           },

--- a/syntaxes/cadence.tmGrammar.json
+++ b/syntaxes/cadence.tmGrammar.json
@@ -292,7 +292,7 @@
       "keywords": {
         "patterns": [
           {
-            "match": "(?<!\\.)\\b(?:if|else)\\b",
+            "match": "(?<!\\.)\\b(?:if|else|switch|case|default)\\b",
             "name": "keyword.control.branch.cadence"
           },
           {
@@ -300,7 +300,7 @@
             "name": "keyword.control.transfer.cadence"
           },
           {
-            "match": "(?<!\\.)\\b(?:while)\\b",
+            "match": "(?<!\\.)\\b(?:while|for|in)\\b",
             "name": "keyword.control.loop.cadence"
           },
           {

--- a/syntaxes/cadence.tmGrammar.json
+++ b/syntaxes/cadence.tmGrammar.json
@@ -260,6 +260,10 @@
             "name": "keyword.operator.move.cadence"
           },
           {
+            "match": "<-!",
+            "name": "keyword.operator.force-move.cadence"
+          },
+          {
             "match": "\\+|\\-|\\*|/",
             "name": "keyword.operator.arithmetic.cadence"
           },
@@ -526,7 +530,7 @@
             "name": "entity.name.type.$1.cadence"
           }
         },
-        "end": "=|<-|$",
+        "end": "=|<-|<-!|$",
         "patterns": [
           { "include": "#type" }
         ]


### PR DESCRIPTION
Fixes #24

## Description

- Add support for force assign operator
- Add support for `switch`, `case`, `default`, `for`, and `in` keywords
- Add support for conformance clause
- Fix event declarations 
- Remove unsupported overflowing arithmetic operators

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
