### PR TITLE
Prompt for running flow init to create a CLI config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -33,14 +33,14 @@ export class Config {
     this.configPath = "";
   }
 
-  async readLocalConfig() {
-    const file = await workspace.findFiles('flow.json')
-    if (file.length === 1) {
-      const configFile = file[0]
-      this.configPath = configFile.path;
-    } else {
-      // TODO: show message that file is not present and propose to init it
+  async readLocalConfig(): Promise<boolean> {
+    const file = await workspace.findFiles('flow.json');
+    if (file.length !== 1) {
+      return false;
     }
+    const configFile = file[0]
+    this.configPath = configFile.path;
+    return true;
   }
 
   addAccount(account: Account) {


### PR DESCRIPTION
## Description

The extension and language server now require a Flow CLI config.
If none exits, there is currently only a cryptic "invalid language server initialization options" error.

Prompt the user if they would like to create a new config if it is missing, and run `flow init` if they agree.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
